### PR TITLE
fixed a warning about an unused variable

### DIFF
--- a/lmatrix.c
+++ b/lmatrix.c
@@ -4761,6 +4761,7 @@ static int matrix_load (lua_State *L) {
     status = H5Tclose(type_id);
   status = H5Dclose(dataset_id);
   status = H5Fclose(file_id);
+  (void)status;
   return 1;
 }
 


### PR DESCRIPTION
In lmatrix.c there was another case where the variable "status" was set but not used. This was fixed with the standard approach (void)status;
